### PR TITLE
Properly merge custom and default renderers

### DIFF
--- a/HTML.js
+++ b/HTML.js
@@ -23,6 +23,14 @@ class HTML extends React.Component {
     renderers: HTMLRenderers
   }
 
+  constructor (props) {
+      super(props);
+      this.renderers = {
+        ...HTMLRenderers,
+        ...(this.props.renderers || {})
+      };
+  }
+
   /* ****************************************************************************/
   // Data Lifecycle
   /* ****************************************************************************/
@@ -79,7 +87,7 @@ class HTML extends React.Component {
               parentTagName={parentTagName}
               parentIsText={parentIsText}
               onLinkPress={this.props.onLinkPress}
-              renderers={this.props.renderers}>
+              renderers={this.renderers}>
               {this.renderHtmlAsRN(node.children, node.name, !HTMLStyles.blockElements.has(node.name))}
             </HTMLElement>)
         }


### PR DESCRIPTION
There was a problem with the custom renderers prop.
If you provide some custom renderers, (ie : only for `<h2>`), the default one will not be merged with your custom ones.

Before I realized it, `<img>` weren't showing anymore on my app.

I merged `HTMLRenderers` and the optionnal `renderers` prop in the constructor so I could use it on line 90.

I left untouched `defaultProps`.
