### PR TITLE
Remove PropTypes check and warnings

### DIFF
--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,6 +1,5 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
-import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations'
 
 // We have to do some munging here as the objects are wrapped
 import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -18,11 +18,10 @@ const STYLESETS = Object.freeze({
   IMAGE: 'image'
 })
 
-const stylePropTypes = {
-  [STYLESETS.VIEW]: {...RNTextStylePropTypes},
-  [STYLESETS.TEXT]: {...RNViewStylePropTypes, ...RNTextStylePropTypes},
-  [STYLESETS.IMAGE]: {...RNViewStylePropTypes, ...RNImageStylePropTypes},
-}
+const stylePropTypes = {}
+stylePropTypes[STYLESETS.VIEW] = Object.assign({}, RNViewStylePropTypes)
+stylePropTypes[STYLESETS.TEXT] = Object.assign({}, RNViewStylePropTypes, RNTextStylePropTypes)
+stylePropTypes[STYLESETS.IMAGE] = Object.assign({}, RNViewStylePropTypes, RNImageStylePropTypes)
 
 class HTMLStyles {
 

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,9 +1,16 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
 
-import RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
-import RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
-import RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
+// We have to do some munging here as the objects are wrapped
+import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
+import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
+import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
+const RNTextStylePropTypes = Object.keys(_RNTextStylePropTypes)
+  .reduce((acc, k) => { acc[k] = _RNTextStylePropTypes[k]; return acc }, {})
+const RNViewStylePropTypes = Object.keys(_RNViewStylePropTypes)
+  .reduce((acc, k) => { acc[k] = _RNViewStylePropTypes[k]; return acc }, {})
+const RNImageStylePropTypes = Object.keys(_RNImageStylePropTypes)
+  .reduce((acc, k) => { acc[k] = _RNImageStylePropTypes[k]; return acc }, {})
 
 const STYLESETS = Object.freeze({
   VIEW: 'view',
@@ -11,11 +18,10 @@ const STYLESETS = Object.freeze({
   IMAGE: 'image'
 })
 
-const stylePropTypes = {
-  [STYLESETS.VIEW]: {...RNTextStylePropTypes},
-  [STYLESETS.TEXT]: {...RNViewStylePropTypes, ...RNTextStylePropTypes},
-  [STYLESETS.IMAGE]: {...RNViewStylePropTypes, ...RNImageStylePropTypes},
-}
+const stylePropTypes = {}
+stylePropTypes[STYLESETS.VIEW] = Object.assign({}, RNViewStylePropTypes)
+stylePropTypes[STYLESETS.TEXT] = Object.assign({}, RNViewStylePropTypes, RNTextStylePropTypes)
+stylePropTypes[STYLESETS.IMAGE] = Object.assign({}, RNViewStylePropTypes, RNImageStylePropTypes)
 
 class HTMLStyles {
 
@@ -43,12 +49,12 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-  * Small utility for generating heading styles
-  * @param baseFontSize: the basic font size
-  * @param fontMultiplier: the amount to multiply the font size by
-  * @param marginMultiplier: the amount to multiply the margin by
-  * @return a style def for a heading
-  */
+   * Small utility for generating heading styles
+   * @param baseFontSize: the basic font size
+   * @param fontMultiplier: the amount to multiply the font size by
+   * @param marginMultiplier: the amount to multiply the margin by
+   * @return a style def for a heading
+   */
   _generateHeadingStyle (baseFontSize, fontMultiplier, marginMultiplier) {
     return {
       fontSize: baseFontSize * fontMultiplier,
@@ -59,9 +65,9 @@ class HTMLStyles {
   }
 
   /**
-  * Generates the default styles
-  * @return the stylesheet
-  */
+   * Generates the default styles
+   * @return the stylesheet
+   */
   _generateDefaultStyles () {
     // These styles are mainly adapted from
     // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css
@@ -124,10 +130,10 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-  * Converts a html style string to an object
-  * @param str: the style string
-  * @return the style as an obect
-  */
+   * Converts a html style string to an object
+   * @param str: the style string
+   * @return the style as an obect
+   */
   cssStringToObject (str) {
     return str
       .split(';')
@@ -141,11 +147,11 @@ class HTMLStyles {
   }
 
   /**
-  * Converts a html style to its equavalent react native style
-  * @param: css: object of key value css strings
-  * @param styleset: the styleset to convert the styles against
-  * @return an object of react native styles
-  */
+   * Converts a html style to its equavalent react native style
+   * @param: css: object of key value css strings
+   * @param styleset: the styleset to convert the styles against
+   * @return an object of react native styles
+   */
   cssToRNStyle (css, styleset) {
     const styleProps = stylePropTypes[styleset]
     return Object.keys(css)
@@ -179,10 +185,10 @@ class HTMLStyles {
   }
 
   /**
-  * @param str: the css style string
-  * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
-  * @return a react native style object
-  */
+   * @param str: the css style string
+   * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
+   * @return a react native style object
+   */
   cssStringToRNStyle (str, styleset = STYLESETS.TEXT) {
     return this.cssToRNStyle(this.cssStringToObject(str), styleset)
   }

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
+import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations'
 
 // We have to do some munging here as the objects are wrapped
 import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
@@ -49,12 +50,12 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-   * Small utility for generating heading styles
-   * @param baseFontSize: the basic font size
-   * @param fontMultiplier: the amount to multiply the font size by
-   * @param marginMultiplier: the amount to multiply the margin by
-   * @return a style def for a heading
-   */
+  * Small utility for generating heading styles
+  * @param baseFontSize: the basic font size
+  * @param fontMultiplier: the amount to multiply the font size by
+  * @param marginMultiplier: the amount to multiply the margin by
+  * @return a style def for a heading
+  */
   _generateHeadingStyle (baseFontSize, fontMultiplier, marginMultiplier) {
     return {
       fontSize: baseFontSize * fontMultiplier,
@@ -65,9 +66,9 @@ class HTMLStyles {
   }
 
   /**
-   * Generates the default styles
-   * @return the stylesheet
-   */
+  * Generates the default styles
+  * @return the stylesheet
+  */
   _generateDefaultStyles () {
     // These styles are mainly adapted from
     // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css
@@ -130,10 +131,10 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-   * Converts a html style string to an object
-   * @param str: the style string
-   * @return the style as an obect
-   */
+  * Converts a html style string to an object
+  * @param str: the style string
+  * @return the style as an obect
+  */
   cssStringToObject (str) {
     return str
       .split(';')
@@ -147,11 +148,11 @@ class HTMLStyles {
   }
 
   /**
-   * Converts a html style to its equavalent react native style
-   * @param: css: object of key value css strings
-   * @param styleset: the styleset to convert the styles against
-   * @return an object of react native styles
-   */
+  * Converts a html style to its equavalent react native style
+  * @param: css: object of key value css strings
+  * @param styleset: the styleset to convert the styles against
+  * @return an object of react native styles
+  */
   cssToRNStyle (css, styleset) {
     const styleProps = stylePropTypes[styleset]
     return Object.keys(css)
@@ -185,10 +186,10 @@ class HTMLStyles {
   }
 
   /**
-   * @param str: the css style string
-   * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
-   * @return a react native style object
-   */
+  * @param str: the css style string
+  * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
+  * @return a react native style object
+  */
   cssStringToRNStyle (str, styleset = STYLESETS.TEXT) {
     return this.cssToRNStyle(this.cssStringToObject(str), styleset)
   }

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
+import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations'
 
 // We have to do some munging here as the objects are wrapped
 import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
@@ -49,12 +50,12 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-  * Small utility for generating heading styles
-  * @param baseFontSize: the basic font size
-  * @param fontMultiplier: the amount to multiply the font size by
-  * @param marginMultiplier: the amount to multiply the margin by
-  * @return a style def for a heading
-  */
+   * Small utility for generating heading styles
+   * @param baseFontSize: the basic font size
+   * @param fontMultiplier: the amount to multiply the font size by
+   * @param marginMultiplier: the amount to multiply the margin by
+   * @return a style def for a heading
+   */
   _generateHeadingStyle (baseFontSize, fontMultiplier, marginMultiplier) {
     return {
       fontSize: baseFontSize * fontMultiplier,
@@ -65,9 +66,9 @@ class HTMLStyles {
   }
 
   /**
-  * Generates the default styles
-  * @return the stylesheet
-  */
+   * Generates the default styles
+   * @return the stylesheet
+   */
   _generateDefaultStyles () {
     // These styles are mainly adapted from
     // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css
@@ -130,10 +131,10 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-  * Converts a html style string to an object
-  * @param str: the style string
-  * @return the style as an obect
-  */
+   * Converts a html style string to an object
+   * @param str: the style string
+   * @return the style as an obect
+   */
   cssStringToObject (str) {
     return str
       .split(';')
@@ -147,11 +148,11 @@ class HTMLStyles {
   }
 
   /**
-  * Converts a html style to its equavalent react native style
-  * @param: css: object of key value css strings
-  * @param styleset: the styleset to convert the styles against
-  * @return an object of react native styles
-  */
+   * Converts a html style to its equavalent react native style
+   * @param: css: object of key value css strings
+   * @param styleset: the styleset to convert the styles against
+   * @return an object of react native styles
+   */
   cssToRNStyle (css, styleset) {
     const styleProps = stylePropTypes[styleset]
     return Object.keys(css)
@@ -168,13 +169,21 @@ class HTMLStyles {
       .map(([key, value]) => {
         if (!styleProps[key]) { return undefined }
 
-        // See if we can convert a 20px to a 20 automagically
-        if (styleProps[key] === React.PropTypes.number) {
-          const numericValue = parseFloat(value.replace('px', ''))
-          if (!isNaN(numericValue)) { return [key, numericValue] }
+        const testStyle = {}
+        testStyle[key] = value
+        if (styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
+          // See if we can convert a 20px to a 20 automagically
+          if (styleProps[key] === React.PropTypes.number) {
+            const numericValue = parseFloat(value.replace('px', ''))
+            if (!isNaN(numericValue)) {
+              testStyle[key] = numericValue
+              if (!styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
+                return [key, numericValue]
+              }
+            }
+          }
           return undefined
         }
-
         return [key, value]
       })
       .filter((prop) => prop !== undefined)
@@ -185,10 +194,10 @@ class HTMLStyles {
   }
 
   /**
-  * @param str: the css style string
-  * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
-  * @return a react native style object
-  */
+   * @param str: the css style string
+   * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
+   * @return a react native style object
+   */
   cssStringToRNStyle (str, styleset = STYLESETS.TEXT) {
     return this.cssToRNStyle(this.cssStringToObject(str), styleset)
   }

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,9 +1,16 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
 
-import RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
-import RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
-import RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
+// We have to do some munging here as the objects are wrapped
+import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
+import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
+import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
+const RNTextStylePropTypes = Object.keys(_RNTextStylePropTypes)
+  .reduce((acc, k) => { acc[k] = _RNTextStylePropTypes[k]; return acc }, {})
+const RNViewStylePropTypes = Object.keys(_RNViewStylePropTypes)
+  .reduce((acc, k) => { acc[k] = _RNViewStylePropTypes[k]; return acc }, {})
+const RNImageStylePropTypes = Object.keys(_RNImageStylePropTypes)
+  .reduce((acc, k) => { acc[k] = _RNImageStylePropTypes[k]; return acc }, {})
 
 const STYLESETS = Object.freeze({
   VIEW: 'view',

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,17 +1,9 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
-import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations'
 
-// We have to do some munging here as the objects are wrapped
-import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
-import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
-import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
-const RNTextStylePropTypes = Object.keys(_RNTextStylePropTypes)
-  .reduce((acc, k) => { acc[k] = _RNTextStylePropTypes[k]; return acc }, {})
-const RNViewStylePropTypes = Object.keys(_RNViewStylePropTypes)
-  .reduce((acc, k) => { acc[k] = _RNViewStylePropTypes[k]; return acc }, {})
-const RNImageStylePropTypes = Object.keys(_RNImageStylePropTypes)
-  .reduce((acc, k) => { acc[k] = _RNImageStylePropTypes[k]; return acc }, {})
+import RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
+import RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
+import RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
 
 const STYLESETS = Object.freeze({
   VIEW: 'view',
@@ -19,10 +11,11 @@ const STYLESETS = Object.freeze({
   IMAGE: 'image'
 })
 
-const stylePropTypes = {}
-stylePropTypes[STYLESETS.VIEW] = Object.assign({}, RNViewStylePropTypes)
-stylePropTypes[STYLESETS.TEXT] = Object.assign({}, RNViewStylePropTypes, RNTextStylePropTypes)
-stylePropTypes[STYLESETS.IMAGE] = Object.assign({}, RNViewStylePropTypes, RNImageStylePropTypes)
+const stylePropTypes = {
+  [STYLESETS.VIEW]: {...RNTextStylePropTypes},
+  [STYLESETS.TEXT]: {...RNViewStylePropTypes, ...RNTextStylePropTypes},
+  [STYLESETS.IMAGE]: {...RNViewStylePropTypes, ...RNImageStylePropTypes},
+}
 
 class HTMLStyles {
 
@@ -50,12 +43,12 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-   * Small utility for generating heading styles
-   * @param baseFontSize: the basic font size
-   * @param fontMultiplier: the amount to multiply the font size by
-   * @param marginMultiplier: the amount to multiply the margin by
-   * @return a style def for a heading
-   */
+  * Small utility for generating heading styles
+  * @param baseFontSize: the basic font size
+  * @param fontMultiplier: the amount to multiply the font size by
+  * @param marginMultiplier: the amount to multiply the margin by
+  * @return a style def for a heading
+  */
   _generateHeadingStyle (baseFontSize, fontMultiplier, marginMultiplier) {
     return {
       fontSize: baseFontSize * fontMultiplier,
@@ -66,9 +59,9 @@ class HTMLStyles {
   }
 
   /**
-   * Generates the default styles
-   * @return the stylesheet
-   */
+  * Generates the default styles
+  * @return the stylesheet
+  */
   _generateDefaultStyles () {
     // These styles are mainly adapted from
     // https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css
@@ -131,10 +124,10 @@ class HTMLStyles {
   /* ****************************************************************************/
 
   /**
-   * Converts a html style string to an object
-   * @param str: the style string
-   * @return the style as an obect
-   */
+  * Converts a html style string to an object
+  * @param str: the style string
+  * @return the style as an obect
+  */
   cssStringToObject (str) {
     return str
       .split(';')
@@ -148,11 +141,11 @@ class HTMLStyles {
   }
 
   /**
-   * Converts a html style to its equavalent react native style
-   * @param: css: object of key value css strings
-   * @param styleset: the styleset to convert the styles against
-   * @return an object of react native styles
-   */
+  * Converts a html style to its equavalent react native style
+  * @param: css: object of key value css strings
+  * @param styleset: the styleset to convert the styles against
+  * @return an object of react native styles
+  */
   cssToRNStyle (css, styleset) {
     const styleProps = stylePropTypes[styleset]
     return Object.keys(css)
@@ -169,21 +162,13 @@ class HTMLStyles {
       .map(([key, value]) => {
         if (!styleProps[key]) { return undefined }
 
-        const testStyle = {}
-        testStyle[key] = value
-        if (styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
-          // See if we can convert a 20px to a 20 automagically
-          if (styleProps[key] === React.PropTypes.number) {
-            const numericValue = parseFloat(value.replace('px', ''))
-            if (!isNaN(numericValue)) {
-              testStyle[key] = numericValue
-              if (!styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
-                return [key, numericValue]
-              }
-            }
-          }
+        // See if we can convert a 20px to a 20 automagically
+        if (styleProps[key] === React.PropTypes.number) {
+          const numericValue = parseFloat(value.replace('px', ''))
+          if (!isNaN(numericValue)) { return [key, numericValue] }
           return undefined
         }
+
         return [key, value]
       })
       .filter((prop) => prop !== undefined)
@@ -194,10 +179,10 @@ class HTMLStyles {
   }
 
   /**
-   * @param str: the css style string
-   * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
-   * @return a react native style object
-   */
+  * @param str: the css style string
+  * @param styleset=STYLESETS.TEXT: the styleset to convert the styles against
+  * @return a react native style object
+  */
   cssStringToRNStyle (str, styleset = STYLESETS.TEXT) {
     return this.cssToRNStyle(this.cssStringToObject(str), styleset)
   }

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,17 +1,9 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
-import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations'
 
-// We have to do some munging here as the objects are wrapped
-import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
-import _RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
-import _RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
-const RNTextStylePropTypes = Object.keys(_RNTextStylePropTypes)
-  .reduce((acc, k) => { acc[k] = _RNTextStylePropTypes[k]; return acc }, {})
-const RNViewStylePropTypes = Object.keys(_RNViewStylePropTypes)
-  .reduce((acc, k) => { acc[k] = _RNViewStylePropTypes[k]; return acc }, {})
-const RNImageStylePropTypes = Object.keys(_RNImageStylePropTypes)
-  .reduce((acc, k) => { acc[k] = _RNImageStylePropTypes[k]; return acc }, {})
+import RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
+import RNViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
+import RNImageStylePropTypes from 'react-native/Libraries/Image/ImageStylePropTypes'
 
 const STYLESETS = Object.freeze({
   VIEW: 'view',
@@ -19,10 +11,11 @@ const STYLESETS = Object.freeze({
   IMAGE: 'image'
 })
 
-const stylePropTypes = {}
-stylePropTypes[STYLESETS.VIEW] = Object.assign({}, RNViewStylePropTypes)
-stylePropTypes[STYLESETS.TEXT] = Object.assign({}, RNViewStylePropTypes, RNTextStylePropTypes)
-stylePropTypes[STYLESETS.IMAGE] = Object.assign({}, RNViewStylePropTypes, RNImageStylePropTypes)
+const stylePropTypes = {
+  [STYLESETS.VIEW]: {...RNTextStylePropTypes},
+  [STYLESETS.TEXT]: {...RNViewStylePropTypes, ...RNTextStylePropTypes},
+  [STYLESETS.IMAGE]: {...RNViewStylePropTypes, ...RNImageStylePropTypes},
+}
 
 class HTMLStyles {
 
@@ -169,21 +162,13 @@ class HTMLStyles {
       .map(([key, value]) => {
         if (!styleProps[key]) { return undefined }
 
-        const testStyle = {}
-        testStyle[key] = value
-        if (styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
-          // See if we can convert a 20px to a 20 automagically
-          if (styleProps[key] === React.PropTypes.number) {
-            const numericValue = parseFloat(value.replace('px', ''))
-            if (!isNaN(numericValue)) {
-              testStyle[key] = numericValue
-              if (!styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
-                return [key, numericValue]
-              }
-            }
-          }
+        // See if we can convert a 20px to a 20 automagically
+        if (styleProps[key] === React.PropTypes.number) {
+          const numericValue = parseFloat(value.replace('px', ''))
+          if (!isNaN(numericValue)) { return [key, numericValue] }
           return undefined
         }
+
         return [key, value]
       })
       .filter((prop) => prop !== undefined)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-native-component",
     "html"
   ],
-  "version": "1.0.6",
+  "version": "1.0.7",
   "scripts": {
     "test": "standard"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-native-component",
     "html"
   ],
-  "version": "1.0.7-tm.6",
+  "version": "1.0.6",
   "scripts": {
     "test": "standard"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-native-component",
     "html"
   ],
-  "version": "1.0.7-tm.4",
+  "version": "1.0.7-tm.5",
   "scripts": {
     "test": "standard"
   },

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "react-native-component",
     "html"
   ],
-  "version": "1.0.6",
+  "version": "1.0.7-tm.4",
   "scripts": {
     "test": "standard"
   },
   "dependencies": {
-    "buffer": "^4.5.1",
+    "buffer": "^5.0.0",
     "events": "^1.1.0",
     "html-entities": "^1.2.0",
     "htmlparser2": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-native-component",
     "html"
   ],
-  "version": "1.0.7-tm.5",
+  "version": "1.0.7-tm.6",
   "scripts": {
     "test": "standard"
   },


### PR DESCRIPTION
Whenever you try and apply styles through html css - you're using propType functions directly which is throwing warnings that it will be removed in the next major version.

I understand why it's not feasible to use the standalone PropTypes package directly, as it isn't possible to infer the PropTypes functions from 'TextStylePropTypes' etc.

The original code would fail silently on invalid styles, I'm not entirely convinced that is the correct decision. So this basically removes the silent failure highlighting errors in styling, and removes the dependancy on PropTypes.

I've also bumped buffer to 5.0.0 - 4.9.1 was causing some errors with the Object.assign polyfill.