### PR TITLE
Allow to style wrapping view

### DIFF
--- a/HTML.js
+++ b/HTML.js
@@ -97,7 +97,7 @@ class HTML extends React.Component {
     parser.write(this.props.html)
     parser.done()
 
-    return (<View>{rnNodes}</View>)
+    return (<View style={this.props.style}>{rnNodes}</View>)
   }
 }
 

--- a/HTML.js
+++ b/HTML.js
@@ -48,7 +48,7 @@ class HTML extends React.Component {
         if (node.type === 'text') {
           const str = HTMLTextNode.removeWhitespaceListHTML(node.data, index, parentTagName)
           if (str.length) {
-            return (<HTMLTextNode key={index}>{str}</HTMLTextNode>)
+            return (<HTMLTextNode style={this.props.defaultTextNodeStyle} key={index}>{str}</HTMLTextNode>)
           } else {
             return undefined
           }

--- a/HTMLStyles.js
+++ b/HTMLStyles.js
@@ -1,6 +1,5 @@
 import { StyleSheet } from 'react-native'
 import React from 'react'
-import ReactPropTypeLocations from 'react/lib/ReactPropTypeLocations'
 
 // We have to do some munging here as the objects are wrapped
 import _RNTextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
@@ -171,13 +170,13 @@ class HTMLStyles {
 
         const testStyle = {}
         testStyle[key] = value
-        if (styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
+        if (styleProps[key](testStyle, key, '', 'prop')) {
           // See if we can convert a 20px to a 20 automagically
           if (styleProps[key] === React.PropTypes.number) {
             const numericValue = parseFloat(value.replace('px', ''))
             if (!isNaN(numericValue)) {
               testStyle[key] = numericValue
-              if (!styleProps[key](testStyle, key, '', ReactPropTypeLocations.prop)) {
+              if (!styleProps[key](testStyle, key, '', 'prop')) {
                 return [key, numericValue]
               }
             }


### PR DESCRIPTION
Based on https://github.com/Thomas101/react-native-fence-html/pull/21.

Example HTML:
```
<a>Sebastian Pape</a> added 1 picture.
```

Rendered like:
<img width="325" alt="screen shot 2017-04-26 at 7 49 09 am" src="https://cloud.githubusercontent.com/assets/851393/25419772/e2564eca-2a54-11e7-892a-18dfd8c689ad.png">

and can't be styled (displayed inline) as the wrapping `<View>` is not styleable.

With this change you can style the wrapping view like:

```
<HTML 
  style={{flexDirection: 'row', flexWrap: 'wrap'}}
/>
```

Which renders:
<img width="323" alt="screen shot 2017-04-26 at 7 50 45 am" src="https://cloud.githubusercontent.com/assets/851393/25419792/13698f90-2a55-11e7-9957-52c490a9394e.png">
